### PR TITLE
Add site metadata snapshot

### DIFF
--- a/site_meta.json
+++ b/site_meta.json
@@ -1,0 +1,41 @@
+{
+  "navigation": {
+    "root_nav": [
+      {"label": "About", "href": "#about"},
+      {"label": "Skills", "href": "#skills"},
+      {"label": "Projects", "href": "#projects"},
+      {"label": "Contact", "href": "#contact"},
+      {"label": "Blog", "href": "blog.html"}
+    ],
+    "blog_nav": [
+      {"label": "Home", "href": "index.html"}
+    ],
+    "project_nav": [
+      {"label": "Home", "href": "../../index.html"},
+      {"label": "Project", "href": "#canvas-container"}
+    ]
+  },
+  "footer": {
+    "info_text": ["[Daniel Litvak] - 2025", "Hosted with GitHub Pages", "© Powered by AI"],
+    "links": [{"label": "Resources", "href": "sources.html"}],
+    "social_links": [],
+    "contact_links": []
+  },
+  "seo_defaults": {
+    "title": "[Daniel Litvak]",
+    "description": "Portfolio of Daniel Litvak, showcasing projects in WebGL, p5.js, and more.",
+    "keywords": "Daniel Litvak, portfolio, WebGL, p5.js, engineering projects, website, programming, simulations, machine learning, computer science, blog",
+    "author": "Daniel Litvak",
+    "robots": "index, follow",
+    "open_graph": null,
+    "twitter": null,
+    "favicons": ["/assets/favicons/Black Simple.png"]
+  },
+  "analytics": [],
+  "third_party_embeds": [
+    {"provider": "Swiper", "resource": "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"},
+    {"provider": "Swiper", "resource": "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"},
+    {"provider": "Google Fonts", "resource": "https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap"},
+    {"provider": "Google Fonts", "resource": "https://fonts.googleapis.com/css2?family=Red+Hat+Display:ital,wght@0,300..900;1,300..900&display=swap"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add structured site_meta.json capturing navigation, footer, SEO defaults, and third-party resources

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926564f34f4832a85742eefdc886ad0)